### PR TITLE
ros_xsarms amd64 install script remove ROS 2 ignore

### DIFF
--- a/interbotix_ros_xsarms/install/amd64/xsarm_amd64_install.sh
+++ b/interbotix_ros_xsarms/install/amd64/xsarm_amd64_install.sh
@@ -322,6 +322,7 @@ function install_ros2() {
         interbotix_ros_toolboxes/interbotix_perception_toolbox/COLCON_IGNORE
     fi
     rm                                                                                                  \
+      interbotix_ros_core/interbotix_ros_xseries/COLCON_IGNORE                                          \
       interbotix_ros_toolboxes/interbotix_common_toolbox/interbotix_moveit_interface/COLCON_IGNORE      \
       interbotix_ros_toolboxes/interbotix_common_toolbox/interbotix_moveit_interface_msgs/COLCON_IGNORE
     cd interbotix_ros_core


### PR DESCRIPTION
This PR removes the ignore files from the ros_xseries package added in Interbotix/interbotix_ros_core#35