### PR TITLE
Relocate ROS 2 rosdep update

### DIFF
--- a/interbotix_ros_xsarms/install/amd64/xsarm_amd64_install.sh
+++ b/interbotix_ros_xsarms/install/amd64/xsarm_amd64_install.sh
@@ -278,7 +278,7 @@ function install_ros2() {
     python3-colcon-common-extensions
 
   # Check if rosdep sources exist
-  if [ ! -d /etc/ros/rosdep/]; then
+  if [ ! -d /etc/ros/rosdep ]; then
     # If rosdep sources do not exist, can assume that rosdep has not been initialized
     sudo rosdep init
   fi

--- a/interbotix_ros_xsarms/install/amd64/xsarm_amd64_install.sh
+++ b/interbotix_ros_xsarms/install/amd64/xsarm_amd64_install.sh
@@ -259,9 +259,6 @@ function install_ros2() {
     echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(source /etc/os-release && echo "$UBUNTU_CODENAME") main" | sudo tee /etc/apt/sources.list.d/ros2.list > /dev/null
     sudo apt-get update
     sudo apt-get install -yq ros-"$ROS_DISTRO_TO_INSTALL"-desktop
-    if [ -f /etc/ros/rosdep/sources.list.d/20-default.list ]; then
-      sudo rm /etc/ros/rosdep/sources.list.d/20-default.list
-    fi
     echo "source /opt/ros/$ROS_DISTRO_TO_INSTALL/setup.bash" >> ~/.bashrc
   else
     echo "ros-$ROS_DISTRO_TO_INSTALL-desktop-full is already installed!"
@@ -277,11 +274,13 @@ function install_ros2() {
     build-essential                   \
     python3-colcon-common-extensions
 
-  # Check if rosdep sources exist
-  if [ ! -d /etc/ros/rosdep ]; then
-    # If rosdep sources do not exist, can assume that rosdep has not been initialized
-    sudo rosdep init
+  # Remove sources if they exist
+  if [ -f /etc/ros/rosdep/sources.list.d/20-default.list ]; then
+    sudo rm /etc/ros/rosdep/sources.list.d/20-default.list
   fi
+
+  # Initialize rosdep sources
+  sudo rosdep init
 
   # Update local rosdep database, including EoL distros
   rosdep update --include-eol-distros

--- a/interbotix_ros_xsarms/install/amd64/xsarm_amd64_install.sh
+++ b/interbotix_ros_xsarms/install/amd64/xsarm_amd64_install.sh
@@ -263,12 +263,12 @@ function install_ros2() {
       sudo rm /etc/ros/rosdep/sources.list.d/20-default.list
     fi
     echo "source /opt/ros/$ROS_DISTRO_TO_INSTALL/setup.bash" >> ~/.bashrc
-
   else
     echo "ros-$ROS_DISTRO_TO_INSTALL-desktop-full is already installed!"
   fi
   source /opt/ros/"$ROS_DISTRO_TO_INSTALL"/setup.bash
 
+  # Install rosdep and other necessary tools
   sudo apt-get install -yq            \
     python3-rosdep                    \
     python3-rosinstall                \
@@ -276,7 +276,14 @@ function install_ros2() {
     python3-wstool                    \
     build-essential                   \
     python3-colcon-common-extensions
-  sudo rosdep init
+
+  # Check if rosdep sources exist
+  if [ ! -d /etc/ros/rosdep/]; then
+    # If rosdep sources do not exist, can assume that rosdep has not been initialized
+    sudo rosdep init
+  fi
+
+  # Update local rosdep database, including EoL distros
   rosdep update --include-eol-distros
 
   if [ "$INSTALL_PERCEPTION" = true ]; then

--- a/interbotix_ros_xsarms/install/amd64/xsarm_amd64_install.sh
+++ b/interbotix_ros_xsarms/install/amd64/xsarm_amd64_install.sh
@@ -263,19 +263,21 @@ function install_ros2() {
       sudo rm /etc/ros/rosdep/sources.list.d/20-default.list
     fi
     echo "source /opt/ros/$ROS_DISTRO_TO_INSTALL/setup.bash" >> ~/.bashrc
-    sudo apt-get install -yq            \
-      python3-rosdep                    \
-      python3-rosinstall                \
-      python3-rosinstall-generator      \
-      python3-wstool                    \
-      build-essential                   \
-      python3-colcon-common-extensions
-    sudo rosdep init
-    rosdep update --include-eol-distros
+
   else
     echo "ros-$ROS_DISTRO_TO_INSTALL-desktop-full is already installed!"
   fi
   source /opt/ros/"$ROS_DISTRO_TO_INSTALL"/setup.bash
+
+  sudo apt-get install -yq            \
+    python3-rosdep                    \
+    python3-rosinstall                \
+    python3-rosinstall-generator      \
+    python3-wstool                    \
+    build-essential                   \
+    python3-colcon-common-extensions
+  sudo rosdep init
+  rosdep update --include-eol-distros
 
   if [ "$INSTALL_PERCEPTION" = true ]; then
     # Install apriltag ROS Wrapper, no official Apriltag ROS 2 package yet


### PR DESCRIPTION
This PR moves the rosdep installation, initialization, and update outside of ROS 2 installation check. In some cases, ROS 2 could already be installed, but rosdep either hasn't been installed, hasn't been initialized, or hasn't been updated in a long time, preventing rosdep from pulling in required dependencies in later steps.