### PR TITLE
Relocate RPi4 rosdep update

### DIFF
--- a/interbotix_ros_xsarms/install/rpi4/xsarm_rpi4_install.sh
+++ b/interbotix_ros_xsarms/install/rpi4/xsarm_rpi4_install.sh
@@ -154,10 +154,10 @@ function install_essential_packages() {
     sudo pip3 install transforms3d
   fi
   if [ $PY_VERSION == 2 ]; then
-    sudo apt-get install -yq install python-pip
+    sudo apt-get install -yq python-pip
     python -m pip install modern_robotics
   elif [ $PY_VERSION == 3 ]; then
-    sudo apt-get install -yq install python3-pip
+    sudo apt-get install -yq python3-pip
     python3 -m pip install modern_robotics
   else
     failed "Something went wrong. PY_VERSION='$PY_VERSION', should be 2 or 3."

--- a/interbotix_ros_xsarms/install/rpi4/xsarm_rpi4_install.sh
+++ b/interbotix_ros_xsarms/install/rpi4/xsarm_rpi4_install.sh
@@ -173,31 +173,39 @@ function install_ros1() {
     curl -s https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc | sudo apt-key add -
     sudo apt-get update
     sudo apt-get install -yq ros-"$ROS_DISTRO_TO_INSTALL"-desktop-full
-    if [ -f /etc/ros/rosdep/sources.list.d/20-default.list ]; then
-      sudo rm /etc/ros/rosdep/sources.list.d/20-default.list
-    fi
     echo "source /opt/ros/$ROS_DISTRO_TO_INSTALL/setup.bash" >> ~/.bashrc
-    if [ $PY_VERSION == 2 ]; then
-      sudo apt-get install -yq        \
-        python-rosdep                 \
-        python-rosinstall             \
-        python-rosinstall-generator   \
-        python-wstool                 \
-        build-essential
-    elif [ $PY_VERSION == 3 ]; then
-      sudo apt-get install -yq        \
-        python3-rosdep                \
-        python3-rosinstall            \
-        python3-rosinstall-generator  \
-        python3-wstool                \
-        build-essential
-    fi
-    sudo rosdep init
-    rosdep update --include-eol-distros
   else
     echo "ros-$ROS_DISTRO_TO_INSTALL-desktop-full is already installed!"
   fi
   source /opt/ros/"$ROS_DISTRO_TO_INSTALL"/setup.bash
+
+  # Install rosdep and other necessary tools
+  if [ $PY_VERSION == 2 ]; then
+    sudo apt-get install -yq        \
+      python-rosdep                 \
+      python-rosinstall             \
+      python-rosinstall-generator   \
+      python-wstool                 \
+      build-essential
+  elif [ $PY_VERSION == 3 ]; then
+    sudo apt-get install -yq        \
+      python3-rosdep                \
+      python3-rosinstall            \
+      python3-rosinstall-generator  \
+      python3-wstool                \
+      build-essential
+  fi
+
+  # Remove sources if they exist
+  if [ -f /etc/ros/rosdep/sources.list.d/20-default.list ]; then
+    sudo rm /etc/ros/rosdep/sources.list.d/20-default.list
+  fi
+
+  # Initialize rosdep sources
+  sudo rosdep init
+
+  # Update local rosdep database, including EoL distros
+  rosdep update --include-eol-distros
 
   # Install Arm packages
   if source /opt/ros/"$ROS_DISTRO_TO_INSTALL"/setup.bash 2>/dev/null && \
@@ -242,23 +250,31 @@ function install_ros2() {
     echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(source /etc/os-release && echo "$UBUNTU_CODENAME") main" | sudo tee /etc/apt/sources.list.d/ros2.list > /dev/null
     sudo apt-get update
     sudo apt-get install -yq ros-"$ROS_DISTRO_TO_INSTALL"-desktop
-    if [ -f /etc/ros/rosdep/sources.list.d/20-default.list ]; then
-      sudo rm /etc/ros/rosdep/sources.list.d/20-default.list
-    fi
     echo "source /opt/ros/$ROS_DISTRO_TO_INSTALL/setup.bash" >> ~/.bashrc
-    sudo apt-get install -yq            \
-      python3-rosdep                    \
-      python3-rosinstall                \
-      python3-rosinstall-generator      \
-      python3-wstool                    \
-      build-essential                   \
-      python3-colcon-common-extensions
-    sudo rosdep init
-    rosdep update --include-eol-distros
   else
     echo "ros-$ROS_DISTRO_TO_INSTALL-desktop is already installed!"
   fi
   source /opt/ros/"$ROS_DISTRO_TO_INSTALL"/setup.bash
+
+  # Install rosdep and other necessary tools
+  sudo apt-get install -yq            \
+    python3-rosdep                    \
+    python3-rosinstall                \
+    python3-rosinstall-generator      \
+    python3-wstool                    \
+    build-essential                   \
+    python3-colcon-common-extensions
+
+  # Remove sources if they exist
+  if [ -f /etc/ros/rosdep/sources.list.d/20-default.list ]; then
+    sudo rm /etc/ros/rosdep/sources.list.d/20-default.list
+  fi
+
+  # Initialize rosdep sources
+  sudo rosdep init
+
+  # Update local rosdep database, including EoL distros
+  rosdep update --include-eol-distros
 
   # Install Arm packages
   if source /opt/ros/"$ROS_DISTRO_TO_INSTALL"/setup.bash 2>/dev/null && \


### PR DESCRIPTION
This is a repeat of https://github.com/Interbotix/interbotix_ros_manipulators/pull/191 but for the rpi installation script.

This PR moves the rosdep installation, initialization, and update outside of ROS 1/2 installation checks. In some cases, ROS was already installed, but rosdep either hasn't been installed, hasn't been initialized, or hasn't been updated in a long time, preventing rosdep from pulling in required dependencies in later steps.

This PR also fixes a small issue in the Python installation section preventing some packages from getting installed.